### PR TITLE
feat(interface-type-handler): Handle generic interfaces

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -221,7 +221,7 @@ This directory contains a collection of specialized handler modules, each respon
 **Object-Like Type Handlers** (extend `ObjectLikeBaseHandler`):
 
 - <mcfile name="object-type-handler.ts" path="src/handlers/typebox/object/object-type-handler.ts"></mcfile>: Handles TypeScript object types and type literals.
-- <mcfile name="interface-type-handler.ts" path="src/handlers/typebox/object/interface-type-handler.ts"></mcfile>: Handles TypeScript interface declarations, including support for interface inheritance using `Type.Composite` to combine base interfaces with extended properties.
+- <mcfile name="interface-type-handler.ts" path="src/handlers/typebox/object/interface-type-handler.ts"></mcfile>: Handles TypeScript interface declarations, including support for interface inheritance using `Type.Composite` to combine base interfaces with extended properties. Supports generic interfaces with type parameters, generating parameterized functions that accept TypeBox schemas as arguments. Handles generic type calls in heritage clauses, converting expressions like `A<number>` to `A(Type.Number())` for proper TypeBox composition.
 
 **Collection Type Handlers** (extend `CollectionBaseHandler`):
 
@@ -257,7 +257,7 @@ This directory contains a collection of parser classes, each extending the `Base
 - <mcfile name="parse-imports.ts" path="src/parsers/parse-imports.ts"></mcfile>: Implements the `ImportParser` class, responsible for resolving and processing TypeScript import declarations.
 - <mcfile name="parse-type-aliases.ts" path="src/parsers/parse-type-aliases.ts"></mcfile>: Implements the `TypeAliasParser` class, responsible for processing TypeScript `type alias` declarations.
 - <mcfile name="parse-function-declarations.ts" path="src/parsers/parse-function-declarations.ts"></mcfile>: Implements the `FunctionDeclarationParser` class, responsible for processing TypeScript function declarations and converting them to TypeBox function schemas.
-- <mcfile name="parse-interfaces.ts" path="src/parsers/parse-interfaces.ts"></mcfile>: Implements the `InterfaceParser` class, responsible for processing TypeScript interface declarations with support for inheritance through dependency ordering and `Type.Composite` generation.
+- <mcfile name="parse-interfaces.ts" path="src/parsers/parse-interfaces.ts"></mcfile>: Implements the `InterfaceParser` class, responsible for processing TypeScript interface declarations with support for inheritance through dependency ordering and `Type.Composite` generation. Handles generic interfaces by generating parameterized functions with type parameters that accept TypeBox schemas as arguments.
 
 ### Performance Considerations
 

--- a/src/handlers/typebox/object/interface-type-handler.ts
+++ b/src/handlers/typebox/object/interface-type-handler.ts
@@ -1,6 +1,6 @@
 import { ObjectLikeBaseHandler } from '@daxserver/validation-schema-codegen/handlers/typebox/object/object-like-base-handler'
 import { makeTypeCall } from '@daxserver/validation-schema-codegen/utils/typebox-codegen-utils'
-import { InterfaceDeclaration, Node, ts } from 'ts-morph'
+import { HeritageClause, InterfaceDeclaration, Node, ts, TypeParameterDeclaration } from 'ts-morph'
 
 export class InterfaceTypeHandler extends ObjectLikeBaseHandler {
   canHandle(node: Node): boolean {
@@ -8,8 +8,14 @@ export class InterfaceTypeHandler extends ObjectLikeBaseHandler {
   }
 
   handle(node: InterfaceDeclaration): ts.Expression {
+    const typeParameters = node.getTypeParameters()
     const heritageClauses = node.getHeritageClauses()
     const baseObjectType = this.createObjectType(this.processProperties(node.getProperties()))
+
+    // If interface has type parameters, generate a function
+    if (typeParameters.length > 0) {
+      return this.createGenericInterfaceFunction(typeParameters, baseObjectType, heritageClauses)
+    }
 
     if (heritageClauses.length === 0) {
       return baseObjectType
@@ -18,11 +24,17 @@ export class InterfaceTypeHandler extends ObjectLikeBaseHandler {
     const extendedTypes: ts.Expression[] = []
 
     for (const heritageClause of heritageClauses) {
-      if (heritageClause.getToken() === ts.SyntaxKind.ExtendsKeyword) {
-        for (const typeNode of heritageClause.getTypeNodes()) {
-          // For interface inheritance, we reference the already processed interface by name
-          const referencedTypeName = typeNode.getText()
-          extendedTypes.push(ts.factory.createIdentifier(referencedTypeName))
+      if (heritageClause.getToken() !== ts.SyntaxKind.ExtendsKeyword) {
+        continue
+      }
+
+      for (const typeNode of heritageClause.getTypeNodes()) {
+        const typeText = typeNode.getText()
+        const genericCall = this.parseGenericTypeCall(typeText)
+        if (genericCall) {
+          extendedTypes.push(genericCall)
+        } else {
+          extendedTypes.push(ts.factory.createIdentifier(typeText))
         }
       }
     }
@@ -35,5 +47,106 @@ export class InterfaceTypeHandler extends ObjectLikeBaseHandler {
     const allTypes = [...extendedTypes, baseObjectType]
 
     return makeTypeCall('Composite', [ts.factory.createArrayLiteralExpression(allTypes, true)])
+  }
+
+  private createGenericInterfaceFunction(
+    typeParameters: TypeParameterDeclaration[],
+    baseObjectType: ts.Expression,
+    heritageClauses: HeritageClause[],
+  ): ts.Expression {
+    // Create function parameters for each type parameter
+    const functionParams = typeParameters.map((typeParam) => {
+      const paramName = typeParam.getName()
+
+      return ts.factory.createParameterDeclaration(
+        undefined,
+        undefined,
+        ts.factory.createIdentifier(paramName),
+        undefined,
+        ts.factory.createTypeReferenceNode(paramName, undefined),
+        undefined,
+      )
+    })
+
+    // Create function body
+    let functionBody: ts.Expression = baseObjectType
+
+    // Handle heritage clauses for generic interfaces
+    if (heritageClauses.length > 0) {
+      const extendedTypes: ts.Expression[] = []
+
+      for (const heritageClause of heritageClauses) {
+        if (heritageClause.getToken() !== ts.SyntaxKind.ExtendsKeyword) {
+          continue
+        }
+
+        for (const typeNode of heritageClause.getTypeNodes()) {
+          const typeText = typeNode.getText()
+          const genericCall = this.parseGenericTypeCall(typeText)
+          if (genericCall) {
+            extendedTypes.push(genericCall)
+          } else {
+            extendedTypes.push(ts.factory.createIdentifier(typeText))
+          }
+        }
+      }
+
+      if (extendedTypes.length > 0) {
+        const allTypes = [...extendedTypes, baseObjectType]
+        functionBody = makeTypeCall('Composite', [
+          ts.factory.createArrayLiteralExpression(allTypes, true),
+        ])
+      }
+    }
+
+    // Create type parameters for the function
+    const functionTypeParams = typeParameters.map((typeParam) => {
+      const paramName = typeParam.getName()
+      return ts.factory.createTypeParameterDeclaration(
+        undefined,
+        ts.factory.createIdentifier(paramName),
+        ts.factory.createTypeReferenceNode('TSchema', undefined),
+        undefined,
+      )
+    })
+
+    // Create arrow function
+    return ts.factory.createArrowFunction(
+      undefined,
+      ts.factory.createNodeArray(functionTypeParams),
+      functionParams,
+      undefined,
+      ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+      functionBody,
+    )
+  }
+
+  private parseGenericTypeCall(typeText: string): ts.Expression | null {
+    const match = typeText.match(/^([^<]+)<([^>]+)>$/)
+
+    if (match && match[1] && match[2]) {
+      const baseName = match[1].trim()
+      const typeArg = match[2].trim()
+      return ts.factory.createCallExpression(ts.factory.createIdentifier(baseName), undefined, [
+        this.createTypeExpression(typeArg),
+      ])
+    }
+
+    return null
+  }
+
+  private createTypeExpression(typeArg: string): ts.Expression {
+    // Convert common TypeScript types to TypeBox calls
+    switch (typeArg) {
+      case 'number':
+        return makeTypeCall('Number')
+      case 'string':
+        return makeTypeCall('String')
+      case 'boolean':
+        return makeTypeCall('Boolean')
+      default:
+        // For other types, assume it's a reference
+        return ts.factory.createIdentifier(typeArg)
+    }
   }
 }

--- a/src/ts-morph-codegen.ts
+++ b/src/ts-morph-codegen.ts
@@ -30,16 +30,30 @@ export const generateCode = async ({
     overwrite: true,
   })
 
+  // Check if any interfaces have generic type parameters
+  const hasGenericInterfaces = sourceFile
+    .getInterfaces()
+    .some((i) => i.getTypeParameters().length > 0)
+
   // Add imports
+  const namedImports = [
+    'Type',
+    {
+      name: 'Static',
+      isTypeOnly: true,
+    },
+  ]
+
+  if (hasGenericInterfaces) {
+    namedImports.push({
+      name: 'TSchema',
+      isTypeOnly: true,
+    })
+  }
+
   newSourceFile.addImportDeclaration({
     moduleSpecifier: '@sinclair/typebox',
-    namedImports: [
-      'Type',
-      {
-        name: 'Static',
-        isTypeOnly: true,
-      },
-    ],
+    namedImports,
   })
 
   const parserOptions = {

--- a/tests/handlers/typebox/interfaces.test.ts
+++ b/tests/handlers/typebox/interfaces.test.ts
@@ -200,5 +200,35 @@ describe('Interfaces', () => {
         `),
       )
     })
+
+    test('generic types', () => {
+      const sourceFile = createSourceFile(
+        project,
+        `
+          interface A<T> { a: T }
+          interface B extends A<number> { b: number }
+        `,
+      )
+
+      expect(generateFormattedCode(sourceFile)).resolves.toBe(
+        formatWithPrettier(
+          `
+          const A = <T extends TSchema>(T: T) => Type.Object({
+            a: T
+          });
+
+          type A<T extends TSchema> = Static<ReturnType<typeof A<T>>>;
+
+          const B = Type.Composite([A(Type.Number()), Type.Object({
+            b: Type.Number()
+          })]);
+
+          type B = Static<typeof B>;
+        `,
+          true,
+          true,
+        ),
+      )
+    })
   })
 })

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -3,20 +3,29 @@ import synchronizedPrettier from '@prettier/sync'
 import { Project, SourceFile } from 'ts-morph'
 
 const prettierOptions = { parser: 'typescript' as const }
-const typeboxImport = 'import { Type, type Static } from "@sinclair/typebox";\n'
+const typeboxImport = (tschema: string = '') =>
+  `import { Type, type Static${tschema} } from "@sinclair/typebox";\n`
+const typeboxImportTSchema = () => typeboxImport(', type TSchema')
 
 export const createSourceFile = (project: Project, code: string, filePath: string = 'test.ts') => {
   return project.createSourceFile(filePath, code)
 }
 
-export const formatWithPrettier = (input: string, addImport: boolean = true): string => {
-  const code = addImport ? `${typeboxImport}${input}` : input
+export const formatWithPrettier = (
+  input: string,
+  addImport: boolean = true,
+  tschema: boolean = false,
+): string => {
+  const importTypebox = tschema ? typeboxImportTSchema() : typeboxImport()
+  const code = addImport ? `${importTypebox}${input}` : input
+
   return synchronizedPrettier.format(code, prettierOptions)
 }
 
 export const generateFormattedCode = async (
   sourceFile: SourceFile,
   exportEverything: boolean = false,
+  tschema: boolean = false,
 ): Promise<string> => {
   const code = await generateCode({
     sourceCode: sourceFile.getFullText(),
@@ -24,5 +33,6 @@ export const generateFormattedCode = async (
     callerFile: sourceFile.getFilePath(),
     project: sourceFile.getProject(),
   })
-  return formatWithPrettier(code, false)
+
+  return formatWithPrettier(code, false, tschema)
 }


### PR DESCRIPTION
This change adds support for handling generic interfaces in the
`InterfaceTypeHandler`. Previously, the handler only supported
non-generic interfaces. Now, if an interface has type parameters,
the handler will generate a function that takes the type parameters
as arguments and returns the composite type for the interface.

The changes include:

- Adding support for parsing type parameters and heritage clauses
  in the `handle` method.
- Implementing the `createGenericInterfaceFunction` method to
  generate the function for generic interfaces.
- Updating the `parseGenericTypeCall` method to handle generic
  type references in heritage clauses.

These changes allow the `InterfaceTypeHandler` to correctly
generate the TypeBox schema for generic interfaces, which is
necessary for supporting more complex validation schemas.