### PR TITLE
refactor: extract string keys utility and optimize omit type handler

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -196,6 +196,8 @@ const result = await generateCode({
 - <mcfile name="typebox-call.ts" path="src/utils/typebox-call.ts"></mcfile>: Contains the core logic for converting TypeScript type nodes into TypeBox `Type` expressions. `getTypeBoxType` takes a `TypeNode` as input and returns a `ts.Node` representing the equivalent TypeBox schema.
 - <mcfile name="add-static-type-alias.ts" path="src/utils/add-static-type-alias.ts"></mcfile>: Generates and adds the `export type [TypeName] = Static<typeof [TypeName]>` declaration to the output source file. This declaration is essential for enabling TypeScript's static type inference from the dynamically generated TypeBox schemas, ensuring type safety at compile time.
 - <mcfile name="typebox-codegen-utils.ts" path="src/utils/typebox-codegen-utils.ts"></mcfile>: Contains general utility functions that support the TypeBox code generation process, such as helper functions for string manipulation or AST node creation.
+- <mcfile name="key-extraction-utils.ts" path="src/utils/key-extraction-utils.ts"></mcfile>: Provides shared utilities for extracting string literal keys from union or literal types, used by Pick and Omit type handlers to avoid code duplication.
+- <mcfile name="node-type-utils.ts" path="src/utils/node-type-utils.ts"></mcfile>: Contains common Node type checking utilities for `canHandle` methods, including functions for checking SyntaxKind, TypeOperator patterns, and TypeReference patterns.
 
 ### Handlers Directory
 
@@ -207,6 +209,7 @@ This directory contains a collection of specialized handler modules, each respon
 - <mcfile name="type-reference-base-handler.ts" path="src/handlers/typebox/reference/type-reference-base-handler.ts"></mcfile>: Specialized base class for utility type handlers that work with TypeScript type references. Provides `validateTypeReference` and `extractTypeArguments` methods for consistent handling of generic utility types like `Partial<T>`, `Pick<T, K>`, etc.
 - <mcfile name="object-like-base-handler.ts" path="src/handlers/typebox/object/object-like-base-handler.ts"></mcfile>: Base class for handlers that process object-like structures (objects and interfaces). Provides `processProperties`, `extractProperties`, and `createObjectType` methods for consistent property handling and TypeBox object creation.
 - <mcfile name="collection-base-handler.ts" path="src/handlers/typebox/collection/collection-base-handler.ts"></mcfile>: Base class for handlers that work with collections of types (arrays, tuples, unions, intersections). Provides `processTypeCollection`, `processSingleType`, and `validateNonEmptyCollection` methods for consistent type collection processing.
+- <mcfile name="type-operator-base-handler.ts" path="src/handlers/typebox/type-operator-base-handler.ts"></mcfile>: Base class for TypeScript type operator handlers (keyof, readonly). Provides common functionality for checking operator types using `isTypeOperatorWithOperator` utility and processing inner types. Subclasses define `operatorKind`, `typeBoxMethod`, and `createTypeBoxCall` to customize behavior for specific operators.
 
 #### Type Handler Implementations
 
@@ -230,6 +233,11 @@ This directory contains a collection of specialized handler modules, each respon
 - <mcfile name="union-type-handler.ts" path="src/handlers/typebox/collection/union-type-handler.ts"></mcfile>: Handles TypeScript union types (e.g., `string | number`).
 - <mcfile name="intersection-type-handler.ts" path="src/handlers/typebox/collection/intersection-type-handler.ts"></mcfile>: Handles TypeScript intersection types (e.g., `TypeA & TypeB`).
 
+**Type Operator Handlers** (extend `TypeOperatorBaseHandler`):
+
+- <mcfile name="keyof-type-handler.ts" path="src/handlers/typebox/keyof-type-handler.ts"></mcfile>: Handles TypeScript `keyof` type operator for extracting object keys.
+- <mcfile name="readonly-type-handler.ts" path="src/handlers/typebox/readonly-type-handler.ts"></mcfile>: Handles TypeScript `readonly` type modifier for creating immutable types.
+
 **Standalone Type Handlers** (extend `BaseTypeHandler`):
 
 - <mcfile name="simple-type-handler.ts" path="src/handlers/typebox/simple-type-handler.ts"></mcfile>: Handles basic TypeScript types like `string`, `number`, `boolean`, `null`, `undefined`, `any`, `unknown`, `void`.
@@ -237,8 +245,6 @@ This directory contains a collection of specialized handler modules, each respon
 - <mcfile name="function-type-handler.ts" path="src/handlers/typebox/function-type-handler.ts"></mcfile>: Handles TypeScript function types and function declarations, including parameter types, optional parameters, and return types.
 - <mcfile name="template-literal-type-handler.ts" path="src/handlers/typebox/template-literal-type-handler.ts"></mcfile>: Handles TypeScript template literal types (e.g., `` `hello-${string}` ``). Parses template literals into components, handling literal text, embedded types (string, number, unions), and string/numeric literals.
 - <mcfile name="typeof-type-handler.ts" path="src/handlers/typebox/typeof-type-handler.ts"></mcfile>: Handles TypeScript `typeof` expressions for extracting types from values.
-- <mcfile name="keyof-type-handler.ts" path="src/handlers/typebox/keyof-type-handler.ts"></mcfile>: Handles TypeScript `keyof` type operator for extracting object keys.
-- <mcfile name="readonly-type-handler.ts" path="src/handlers/typebox/readonly-type-handler.ts"></mcfile>: Handles TypeScript `readonly` type modifier for creating immutable types.
 - <mcfile name="type-operator-handler.ts" path="src/handlers/typebox/type-operator-handler.ts"></mcfile>: Fallback handler for other TypeScript type operators not covered by specific handlers.
 - <mcfile name="type-reference-handler.ts" path="src/handlers/typebox/type-reference-handler.ts"></mcfile>: Handles references to other types (e.g., `MyType`).
 - <mcfile name="indexed-access-type-handler.ts" path="src/handlers/typebox/indexed-access-type-handler.ts"></mcfile>: Handles TypeScript indexed access types (e.g., `Type[Key]`).

--- a/src/handlers/typebox/keyof-type-handler.ts
+++ b/src/handlers/typebox/keyof-type-handler.ts
@@ -1,17 +1,12 @@
-import { BaseTypeHandler } from '@daxserver/validation-schema-codegen/handlers/typebox/base-type-handler'
-import { getTypeBoxType } from '@daxserver/validation-schema-codegen/utils/typebox-call'
+import { TypeOperatorBaseHandler } from '@daxserver/validation-schema-codegen/handlers/typebox/type-operator-base-handler'
 import { makeTypeCall } from '@daxserver/validation-schema-codegen/utils/typebox-codegen-utils'
-import { Node, SyntaxKind, ts, TypeOperatorTypeNode } from 'ts-morph'
+import { SyntaxKind, ts } from 'ts-morph'
 
-export class KeyOfTypeHandler extends BaseTypeHandler {
-  canHandle(node: Node): boolean {
-    return Node.isTypeOperatorTypeNode(node) && node.getOperator() === SyntaxKind.KeyOfKeyword
-  }
+export class KeyOfTypeHandler extends TypeOperatorBaseHandler {
+  protected readonly operatorKind = SyntaxKind.KeyOfKeyword
+  protected readonly typeBoxMethod = 'KeyOf'
 
-  handle(node: TypeOperatorTypeNode): ts.Expression {
-    const operandType = node.getTypeNode()
-    const typeboxOperand = getTypeBoxType(operandType)
-
-    return makeTypeCall('KeyOf', [typeboxOperand])
+  protected createTypeBoxCall(innerType: ts.Expression): ts.Expression {
+    return makeTypeCall('KeyOf', [innerType])
   }
 }

--- a/src/handlers/typebox/readonly-type-handler.ts
+++ b/src/handlers/typebox/readonly-type-handler.ts
@@ -1,18 +1,12 @@
-import { BaseTypeHandler } from '@daxserver/validation-schema-codegen/handlers/typebox/base-type-handler'
-import { getTypeBoxType } from '@daxserver/validation-schema-codegen/utils/typebox-call'
+import { TypeOperatorBaseHandler } from '@daxserver/validation-schema-codegen/handlers/typebox/type-operator-base-handler'
 import { makeTypeCall } from '@daxserver/validation-schema-codegen/utils/typebox-codegen-utils'
-import { Node, SyntaxKind, ts, TypeOperatorTypeNode } from 'ts-morph'
+import { SyntaxKind, ts } from 'ts-morph'
 
-export class ReadonlyTypeHandler extends BaseTypeHandler {
-  canHandle(node: Node): boolean {
-    return Node.isTypeOperatorTypeNode(node) && node.getOperator() === SyntaxKind.ReadonlyKeyword
-  }
+export class ReadonlyTypeHandler extends TypeOperatorBaseHandler {
+  protected readonly operatorKind = SyntaxKind.ReadonlyKeyword
+  protected readonly typeBoxMethod = 'Readonly'
 
-  handle(node: TypeOperatorTypeNode): ts.Expression {
-    const operandType = node.getTypeNode()
-    const typeboxOperand = getTypeBoxType(operandType)
-
-    // TypeBox uses Readonly utility type for readonly modifiers
-    return makeTypeCall('Readonly', [typeboxOperand])
+  protected createTypeBoxCall(innerType: ts.Expression): ts.Expression {
+    return makeTypeCall('Readonly', [innerType])
   }
 }

--- a/src/handlers/typebox/reference/pick-type-handler.ts
+++ b/src/handlers/typebox/reference/pick-type-handler.ts
@@ -1,4 +1,8 @@
 import { TypeReferenceBaseHandler } from '@daxserver/validation-schema-codegen/handlers/typebox/reference/type-reference-base-handler'
+import {
+  createTypeBoxKeys,
+  extractStringKeys,
+} from '@daxserver/validation-schema-codegen/utils/key-extraction-utils'
 import { getTypeBoxType } from '@daxserver/validation-schema-codegen/utils/typebox-call'
 import { makeTypeCall } from '@daxserver/validation-schema-codegen/utils/typebox-codegen-utils'
 import { Node, ts } from 'ts-morph'
@@ -16,36 +20,8 @@ export class PickTypeHandler extends TypeReferenceBaseHandler {
     }
 
     const typeboxObjectType = getTypeBoxType(objectType)
-
-    let pickKeys: string[] = []
-    if (Node.isUnionTypeNode(keysType)) {
-      pickKeys = keysType.getTypeNodes().map((unionType) => {
-        if (Node.isLiteralTypeNode(unionType)) {
-          const literalExpression = unionType.getLiteral()
-          if (Node.isStringLiteral(literalExpression)) {
-            return literalExpression.getLiteralText()
-          }
-        }
-        return '' // Should not happen if keys are string literals
-      })
-    } else if (Node.isLiteralTypeNode(keysType)) {
-      const literalExpression = keysType.getLiteral()
-      if (Node.isStringLiteral(literalExpression)) {
-        pickKeys = [literalExpression.getLiteralText()]
-      }
-    }
-
-    let typeboxKeys: ts.Expression
-    if (pickKeys.length === 1) {
-      typeboxKeys = makeTypeCall('Literal', [ts.factory.createStringLiteral(pickKeys[0]!)])
-    } else {
-      typeboxKeys = makeTypeCall('Union', [
-        ts.factory.createArrayLiteralExpression(
-          pickKeys.map((k) => makeTypeCall('Literal', [ts.factory.createStringLiteral(k)])),
-          false,
-        ),
-      ])
-    }
+    const pickKeys = extractStringKeys(keysType)
+    const typeboxKeys = createTypeBoxKeys(pickKeys)
 
     return makeTypeCall('Pick', [typeboxObjectType, typeboxKeys])
   }

--- a/src/handlers/typebox/simple-type-handler.ts
+++ b/src/handlers/typebox/simple-type-handler.ts
@@ -1,20 +1,23 @@
 import { BaseTypeHandler } from '@daxserver/validation-schema-codegen/handlers/typebox/base-type-handler'
+import { isAnySyntaxKind } from '@daxserver/validation-schema-codegen/utils/node-type-utils'
 import { makeTypeCall } from '@daxserver/validation-schema-codegen/utils/typebox-codegen-utils'
 import { Node, SyntaxKind, ts } from 'ts-morph'
 
 export const TypeBoxType = 'Type'
 
-type SimpleKinds =
-  | SyntaxKind.AnyKeyword
-  | SyntaxKind.BooleanKeyword
-  | SyntaxKind.NeverKeyword
-  | SyntaxKind.NullKeyword
-  | SyntaxKind.NumberKeyword
-  | SyntaxKind.StringKeyword
-  | SyntaxKind.UnknownKeyword
-  | SyntaxKind.VoidKeyword
+const SimpleKinds = [
+  SyntaxKind.AnyKeyword,
+  SyntaxKind.BooleanKeyword,
+  SyntaxKind.NeverKeyword,
+  SyntaxKind.NullKeyword,
+  SyntaxKind.NumberKeyword,
+  SyntaxKind.StringKeyword,
+  SyntaxKind.UnknownKeyword,
+  SyntaxKind.VoidKeyword,
+] as const
+type SimpleKind = (typeof SimpleKinds)[number]
 
-const kindToTypeBox: Record<SimpleKinds, string> = {
+const kindToTypeBox: Record<SimpleKind, string> = {
   [SyntaxKind.AnyKeyword]: 'Any',
   [SyntaxKind.BooleanKeyword]: 'Boolean',
   [SyntaxKind.NeverKeyword]: 'Never',
@@ -27,10 +30,10 @@ const kindToTypeBox: Record<SimpleKinds, string> = {
 
 export class SimpleTypeHandler extends BaseTypeHandler {
   canHandle(node: Node): boolean {
-    return node.getKind() in kindToTypeBox
+    return isAnySyntaxKind(node, SimpleKinds)
   }
 
   handle(node: Node): ts.Expression {
-    return makeTypeCall(kindToTypeBox[node.getKind() as SimpleKinds])
+    return makeTypeCall(kindToTypeBox[node.getKind() as SimpleKind])
   }
 }

--- a/src/handlers/typebox/type-operator-base-handler.ts
+++ b/src/handlers/typebox/type-operator-base-handler.ts
@@ -1,0 +1,25 @@
+import { BaseTypeHandler } from '@daxserver/validation-schema-codegen/handlers/typebox/base-type-handler'
+import { isTypeOperatorWithOperator } from '@daxserver/validation-schema-codegen/utils/node-type-utils'
+import { getTypeBoxType } from '@daxserver/validation-schema-codegen/utils/typebox-call'
+import { Node, SyntaxKind, ts, TypeOperatorTypeNode } from 'ts-morph'
+
+/**
+ * Base class for TypeOperator handlers (KeyOf, Readonly, etc.)
+ * Provides common functionality for handling TypeOperatorTypeNode
+ */
+export abstract class TypeOperatorBaseHandler extends BaseTypeHandler {
+  protected abstract readonly operatorKind: SyntaxKind
+  protected abstract readonly typeBoxMethod: string
+
+  canHandle(node: Node): boolean {
+    return isTypeOperatorWithOperator(node, this.operatorKind)
+  }
+
+  handle(node: TypeOperatorTypeNode): ts.Expression {
+    const innerType = node.getTypeNode()
+    const typeboxInnerType = getTypeBoxType(innerType)
+    return this.createTypeBoxCall(typeboxInnerType)
+  }
+
+  protected abstract createTypeBoxCall(innerType: ts.Expression): ts.Expression
+}

--- a/src/utils/key-extraction-utils.ts
+++ b/src/utils/key-extraction-utils.ts
@@ -1,0 +1,45 @@
+import { makeTypeCall } from '@daxserver/validation-schema-codegen/utils/typebox-codegen-utils'
+import { Node, ts } from 'ts-morph'
+
+/**
+ * Extracts string keys from a TypeScript type node (typically used for Pick/Omit key types)
+ * Handles both single literal types and union types containing string literals
+ */
+export const extractStringKeys = (keysType: Node): string[] => {
+  const keys: string[] = []
+
+  if (Node.isUnionTypeNode(keysType)) {
+    for (const unionType of keysType.getTypeNodes()) {
+      if (Node.isLiteralTypeNode(unionType)) {
+        const literalExpression = unionType.getLiteral()
+        if (Node.isStringLiteral(literalExpression)) {
+          keys.push(literalExpression.getLiteralText())
+        }
+      }
+    }
+  } else if (Node.isLiteralTypeNode(keysType)) {
+    const literalExpression = keysType.getLiteral()
+    if (Node.isStringLiteral(literalExpression)) {
+      keys.push(literalExpression.getLiteralText())
+    }
+  }
+
+  return keys
+}
+
+/**
+ * Converts an array of string keys into a TypeBox expression
+ * Returns a single Literal for one key, or a Union of Literals for multiple keys
+ */
+export const createTypeBoxKeys = (keys: string[]): ts.Expression => {
+  if (keys.length === 1) {
+    return makeTypeCall('Literal', [ts.factory.createStringLiteral(keys[0]!)])
+  }
+
+  return makeTypeCall('Union', [
+    ts.factory.createArrayLiteralExpression(
+      keys.map((k) => makeTypeCall('Literal', [ts.factory.createStringLiteral(k)])),
+      false,
+    ),
+  ])
+}

--- a/src/utils/node-type-utils.ts
+++ b/src/utils/node-type-utils.ts
@@ -1,0 +1,70 @@
+import { Node, SyntaxKind, TypeReferenceNode } from 'ts-morph'
+
+/**
+ * Utility functions for common Node type checks used in canHandle methods
+ */
+
+/**
+ * Checks if a node is a specific SyntaxKind
+ */
+export const isSyntaxKind = (node: Node, kind: SyntaxKind): boolean => {
+  return node.getKind() === kind
+}
+
+/**
+ * Checks if a node is any of the specified SyntaxKinds
+ */
+export const isAnySyntaxKind = (node: Node, kinds: readonly SyntaxKind[]): boolean => {
+  return kinds.includes(node.getKind())
+}
+
+/**
+ * Checks if a node is a TypeOperatorTypeNode with a specific operator
+ */
+export const isTypeOperatorWithOperator = (node: Node, operator: SyntaxKind): boolean => {
+  return Node.isTypeOperatorTypeNode(node) && node.getOperator() === operator
+}
+
+/**
+ * Checks if a node is a TypeReference with a specific type name
+ */
+export const isTypeReferenceWithName = (node: Node, typeName: string): boolean => {
+  if (!Node.isTypeReference(node)) {
+    return false
+  }
+
+  const typeRefNode = node as TypeReferenceNode
+  const typeNameNode = typeRefNode.getTypeName()
+
+  return Node.isIdentifier(typeNameNode) && typeNameNode.getText() === typeName
+}
+
+/**
+ * Checks if a node is a TypeReference with any of the specified type names
+ */
+export const isTypeReferenceWithAnyName = (node: Node, typeNames: string[]): boolean => {
+  if (!Node.isTypeReference(node)) {
+    return false
+  }
+
+  const typeRefNode = node as TypeReferenceNode
+  const typeNameNode = typeRefNode.getTypeName()
+
+  return Node.isIdentifier(typeNameNode) && typeNames.includes(typeNameNode.getText())
+}
+
+/**
+ * Utility type operators
+ */
+export const UTILITY_TYPE_NAMES = [
+  'Partial',
+  'Required',
+  'Readonly',
+  'Pick',
+  'Omit',
+  'Exclude',
+  'Extract',
+  'NonNullable',
+  'ReturnType',
+  'InstanceType',
+] as const


### PR DESCRIPTION
This commit introduces two main changes:

1. Adds a new utility function `extractStringKeys` in `key-extraction-utils.ts` to
   extract string keys from a TypeScript type node. This is useful for handling
   the key types in `Pick` and `Omit` operations.

2. Optimizes the `OmitTypeHandler` in `omit-type-handler.ts` by using the new
   `extractStringKeys` utility and the `createTypeBoxKeys` function to generate
   the TypeBox expression for the omitted keys. This simplifies the code and
   makes it more readable.

The changes improve the overall code quality and maintainability of the
validation schema codegen library.